### PR TITLE
Add support for maxim ds3231 backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,5 +4,6 @@ zephyr_library()
 
 zephyr_include_directories(include)
 zephyr_library_sources_ifdef(CONFIG_STM32_RTC_CALENDAR drivers/stm32/stm32_rtc_cal.c)
+zephyr_library_sources_ifdef(CONFIG_DS3231_RTC_CALENDAR drivers/ds3231/ds3231_cal.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE calendar_handlers.c)
 endif()

--- a/Kconfig
+++ b/Kconfig
@@ -21,4 +21,5 @@ config CALENDAR_INIT_TIME_UNIX_TIMESTAMP
 		where epoch is January 1 1970
 
 rsource "Kconfig.stm32"
+rsource "Kconfig.ds3231"
 endif

--- a/Kconfig.ds3231
+++ b/Kconfig.ds3231
@@ -1,0 +1,9 @@
+# Copyright (c) 2020 Brian Bradley
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig DS3231_RTC_CALENDAR
+	bool "Maxim DS3231 RTC based calendar API implementation"
+	select COUNTER
+	select COUNTER_MAXIM_DS3231
+	help
+	  Enable driver for Maxim DS3231 rtc time api

--- a/drivers/ds3231/ds3231_cal.c
+++ b/drivers/ds3231/ds3231_cal.c
@@ -1,0 +1,135 @@
+/**
+ * @file ds3231_cal.c
+ * @author Brian Bradley (brian.bradley.p@gmail.com)
+ * @brief 
+ * @date 2021-06-18
+ * 
+ * @copyright Copyright (C) 2020 Brian Bradley
+ * 
+ * SPDX-License-Identifier: Apache-2.0
+ * 
+ */
+
+#include <zephyr.h>
+#include <device.h>
+#include <zcal/calendar.h>
+#include <logging/log.h>
+#include <drivers/rtc/maxim_ds3231.h>
+
+#define DT_DRV_COMPAT calendar
+
+#if DT_HAS_CHOSEN(zcal_rtc)
+#define CALENDAR_DEV_LABEL DT_LABEL(DT_CHOSEN(zcal_rtc))
+#else
+#define CALENDAR_DEV_LABEL DT_PROP_BY_PHANDLE(DT_PATH(calendar), rtc, label)
+#endif
+
+LOG_MODULE_REGISTER(calendar, CONFIG_CALENDAR_LOG_LEVEL);
+
+struct ds3231_config{
+	const struct device * rtc_dev;
+};
+
+/**
+ * @brief Set the calendar time to the battery backed rtc domain. 
+ * 
+ * This will attempt to maintain subsecond accuracy when updating the time.
+ * As a result, it may take up to a second to complete.
+ * 
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param tm Pointer to the time structure describing the current calendar date
+ * @retval 0 on success
+ * @retval -errno on failure
+ */
+static int ds3231_calendar_settime(const struct device * dev, struct tm * tm) {
+	int rc = 0;
+	const struct ds3231_config * cfg = dev->config;
+	const struct device * rtc = cfg->rtc_dev;
+	if (!rtc){
+		return -ENODEV;
+	}
+	uint32_t syncclock_Hz = maxim_ds3231_syncclock_frequency(rtc);
+	uint32_t syncclock = maxim_ds3231_read_syncclock(rtc);
+	time_t tv_sec = mktime(tm);
+	struct maxim_ds3231_syncpoint sp = {
+		.rtc = {
+			.tv_sec = tv_sec,
+			.tv_nsec = (uint64_t)NSEC_PER_SEC * syncclock / syncclock_Hz,
+		},
+		.syncclock = syncclock,
+	};
+
+	struct k_poll_signal ss;
+	struct sys_notify notify;
+	struct k_poll_event sevt = K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL,
+							    K_POLL_MODE_NOTIFY_ONLY,
+							    &ss);
+
+	k_poll_signal_init(&ss);
+	sys_notify_init_signal(&notify, &ss);
+
+
+	rc = maxim_ds3231_set(rtc, &sp, &notify);
+
+	/* Wait for the set to complete */
+	rc = k_poll(&sevt, 1, K_MSEC(1000));
+
+	rc = maxim_ds3231_get_syncpoint(rtc, &sp);
+	LOG_DBG("wrote sync %d: %u %u at %u", rc,
+	       (uint32_t)sp.rtc.tv_sec, (uint32_t)sp.rtc.tv_nsec,
+	       sp.syncclock);
+
+	return rc;
+}
+
+/**
+ * @brief Function for getting the current calendar time as recorded by the
+ * battery backed rtc domain
+ * 
+ * @param dev Pointer to the device structure for the driver instance.
+ * @param tm Pointer to the time structure which will be populated with the
+ * current calendar date
+ * @retval 0
+ */
+static int ds3231_calendar_gettime(const struct device * dev, struct tm * tm) {
+	const struct ds3231_config * cfg = dev->config;
+	const struct device * rtc = cfg->rtc_dev;
+	if (!rtc){
+		return -ENODEV;
+	}
+	uint32_t now = 0;
+	(void)counter_get_value(rtc, &now);
+	struct tm tv;
+	time_t tnow = now;
+	LOG_DBG("time now %u", now);
+	memcpy(tm, gmtime_r(&tnow, &tv), sizeof(struct tm));
+	return 0;
+}
+
+/**
+ * @brief Initialize calendar API. Gets the underlying rtc device
+ * 
+ * @param dev Pointer to the device structure for the driver instance.
+ * @retval 0
+ */
+static int ds3231_rtc_initilize(const struct device *dev) {
+	const struct device * rtc = device_get_binding(CALENDAR_DEV_LABEL);
+	((struct ds3231_config *)dev->config)->rtc_dev = rtc;
+	if (rtc){
+		return 0;
+	}
+	return -ENODEV;
+}
+
+static const struct calendar_driver_api ds3231_calendar_api = {
+	.settime = ds3231_calendar_settime,
+	.gettime = ds3231_calendar_gettime,
+};
+
+struct ds3231_config ds3231_config = {NULL};
+
+DEVICE_DT_INST_DEFINE(0, ds3231_rtc_initilize, device_pm_control_nop,
+	NULL, &ds3231_config,
+	POST_KERNEL, CONFIG_APPLICATION_INIT_PRIORITY,
+	&ds3231_calendar_api
+); 

--- a/drivers/stm32/stm32_rtc_cal.c
+++ b/drivers/stm32/stm32_rtc_cal.c
@@ -19,7 +19,7 @@
 #include <zcal/calendar.h>
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(stm32rtc, CONFIG_CALENDAR_LOG_LEVEL);
+LOG_MODULE_REGISTER(calendar, CONFIG_CALENDAR_LOG_LEVEL);
 
 // prescaler values for LSE @ 32768 Hz
 #define RTC_PREDIV_ASYNC 0x7F

--- a/dts/bindings/calendar.yaml
+++ b/dts/bindings/calendar.yaml
@@ -1,0 +1,12 @@
+compatible: "calendar"
+
+include: base.yaml
+
+description: Device tree bindings for calendar API
+
+properties:
+  rtc:
+    type: phandle
+    required: true
+    description: The handle of the underlying device used to store time
+  

--- a/include/zcal/calendar.h
+++ b/include/zcal/calendar.h
@@ -25,7 +25,6 @@ extern "C" {
 typedef int (*calendar_api_settime)(const struct device * dev, struct tm * tm);
 typedef int (*calendar_api_gettime)(const struct device * dev, struct tm * tm);
 
-
 __subsystem struct calendar_driver_api {
     calendar_api_settime settime;
     calendar_api_gettime gettime;
@@ -50,7 +49,6 @@ static inline int z_impl_calendar_gettime(const struct device *dev, struct tm *t
 
 	return api->gettime(dev, tm);
 }
-
 
 /**
  * @brief Function for setting the current calendar time to be recorded by the

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -4,4 +4,5 @@
 build:
   cmake: .
   kconfig: Kconfig
-
+  settings:
+    dts_root: .


### PR DESCRIPTION
This implementation leverages the existing drivers already included in the counter API. As a result, a device tree binding was added which is used to select the appropriate handle of the ds3231 configured for use with the counter. Otherwise, it can be selected using a chosen node.

It is probably a good idea to revise the stm32 implementation similarly to remain consistent. Samples should also be added in the future.