### PR TITLE
Refactor ds3231

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,6 @@ using the included device tree bindings
 };
 ```
 
-Or by using a chosen node
-
-```dts
-/ {
-  chosen{
-    zcal,rtc = &calendar_rtc;
-  }
-}
-```
-
 The STM32 implementation is independent of the counter API and so does not need a handle to that device to work.
 As a result, it does not need any device tree configuration.
 
@@ -85,7 +75,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: master
+      revision: main
       import:
         path-prefix: rtos
     - name: zcalendar


### PR DESCRIPTION
Fix a bug where timespec was overflowing when a setpoint was created too far into the boot cycle. Instead, sync to 0 nsec.

Change to selecting the device at compile time instead of searching for the binding at initialization.